### PR TITLE
Add initial documents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What this PR changes/adds
+
+_Briefly describe WHAT your PR changes, which features it adds/modifies._
+
+## Why it does that
+
+_Briefly state why the change was necessary._
+
+## Further notes
+
+_List other areas of the documents that have changed but are not necessarily linked to the main feature. This could be editorial changes or mistakes in example files that were encountered and were fixed inline, etc._
+
+## Linked Issue(s)
+
+Closes # <-- _insert issue number if one exists_
+
+_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+See the [Eclipse Code Of Conduct](https://www.eclipse.org/org/documents/Community_Code_of_Conduct.php).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+# Contributing to the Project
+
+Thank you for being interested in contributing to the [Dataspace Protocol Best Practices](https://projects.eclipse.org/projects/technology.dataspace-protocol-base)!
+
+* [Eclipse Contributor Agreement](#eclipse-contributor-agreement)
+* [How to Contribute](#how-to-contribute)
+    * [Discuss](#discuss)
+    * [Create an Issue](#create-an-issue)
+    * [Submit a Pull Request](#submit-a-pull-request)
+* [EF Project Roles](#ef-project-roles)
+    * [Contributor](#contributor)
+        * [Privileges & Responsibilities](#privileges--responsibilities)
+        * [Becoming a Contributor](#becoming-a-contributor)
+        * [Retirement of Contributors](#retirement-of-contributors)
+    * [Committer](#committer)
+        * [Privileges & Responsibilities](#privileges--responsibilities-1)
+        * [Special Role: Normative Editor](#special-role-normative-editor)
+        * [Becoming a Committer](#becoming-a-committer)
+        * [Retirement of Committers](#retirement-of-committers)
+* [Contact Us](#contact-us)
+
+## Eclipse Contributor Agreement
+
+Before your contribution can be accepted by the project, you need to create and electronically sign an [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ecafaq.php):
+
+1. Log in to the [Eclipse Foundation website](https://accounts.eclipse.org/user/login/). If you still need to, create an account within the Eclipse Foundation.
+2. Click on "Eclipse ECA" and complete the form.
+
+_Note: Be sure to use the same email address in your Eclipse Account that you intend to use when you commit to GitHub._
+
+## How to Contribute
+
+### Discuss
+
+If you want to share an idea to further enhance the project or discuss potential use cases, please feel free to create a [GitHub discussion](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/discussions).
+
+If you feel there is a bug or issue, contribute to the discussions in **existing issues**; otherwise, [create a new issue](#create-an-issue).
+
+### Create an Issue
+
+If you have identified a bug or want to formulate a working item that you want to concentrate on, feel free to create a new issue at the repository's corresponding [GitHub Issues page](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/issues).
+
+**Before doing so, please consider searching for potentially suitable [existing issues](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/issues?q=is%3Aissue+is%3Aopen).**
+
+We also use [GitHub's default label set](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) extended by custom ones to classify issues and improve findability.
+
+If an issue appears to cover changes that will have a (huge) impact on the specification and need to be discussed first, or if you have a question regarding the usage of the protocols, please create a discussion _before_ raising an issue.
+
+Please note that if an issue covers a topic or the response to a question that may be interesting for other contributors or for further discussions, it should be converted to a discussion and not be closed.
+
+### Submit a Pull Request
+
+In addition to the contribution guideline in the [Eclipse project handbook](https://www.eclipse.org/projects/handbook/#contributing), we would appreciate it if your pull request (PR) addressed the following points.
+
+* Conform to the [PR Etiquette](PR_ETIQUETTE.md).
+
+* Always apply the following copyright header to specific files in your work, replacing the fields enclosed by curly brackets "{}" with your identifying information. (Don't include the curly brackets!) Enclose the text using the appropriate comment syntax for the file format.
+
+  "`text
+  Copyright (c) {year} {owner}[ and others]
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0, which is available at
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  SPDX-License-Identifier: Apache-2.0
+
+  Contributors:
+  {name} - {description}
+    ```
+
+* The git commit messages should comply with the following format:
+    ```
+    <prefix>(<scope>): <description>
+    ```
+
+  Use the [imperative mood](https://github.com/git/git/blob/master/Documentation/SubmittingPatches)  as in "fix bug" or "add feature" (lowercase at the beginning) rather than "fixed bug" or "added feature" and [mention the GitHub issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+  All Committers and all commits are bound to the [Developer Certificate of Origin](https://www.eclipse.org/legal/DCO.php). As such, all parties involved in a contribution must have valid ECAs. Additionally, commits can include a ["Signed-off-by" entry](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git).
+
+* PR descriptions should use the current [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+
+* Submit a draft PR early and add people who have previously worked on the same content as the reviewer. Make sure automatic checks pass before marking it as "ready for review":
+
+    * _Intellectual Property Validation_ verifying the [Eclipse CLA](#eclipse-contributor-agreement) has been signed, and commits have been signed-off.
+    * _Prevent Changes to Release Files_ checks if old release documents have been changed unintentionally.
+
+## EF Project Roles
+
+The [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#roles) defines roles for projects such as _Committer_ and _Contributor_.
+
+### Contributor
+
+Anybody can be a Contributor. To be a Contributor, you just need to contribute. Contributions typically take the form of content or documentation submitted to the project's repository, but may also take the form of answering questions in project and community forums, and more.
+
+#### Privileges & Responsibilities
+- Ability to commit code and documentation.
+- Participation in project meetings and discussions.
+- Recognition in project credits and contributions.
+- Adhere to project guidelines and coding standards.
+- Review and provide feedback on contributions from others.
+- Maintain clear communication with the Committer team.
+- Submit high-quality code and documentation.
+- Participate actively in community discussions.
+
+#### Becoming a Contributor
+
+Everyone who contributes to the project is a Contributor. However, official EF Contributors are mentioned on the [project's page](https://projects.eclipse.org/projects/technology.dataspace-protocol-base/who). They have additional rights on GitHub, i.e., to label issues, add assignees, and ask for specific reviewers of PRs.
+
+#### Retirement of Contributors
+
+After one year of inactivity, Contributors are removed from the [project's page](https://projects.eclipse.org/projects/technology.dataspace-protocol-base/who). Although this changes their technical role on GitHub, they remain in the [list of contributors on GitHub](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/graphs/contributors).
+
+### Committer
+
+For Eclipse projects, Committers hold the keys. They decide on contributions and ultimately decide what is delivered to the community.
+
+#### Privileges & Responsibilities
+
+* Full access to commit code directly to the project's repository.
+* Ability to manage and approve contributions from other contributors.
+* Voting rights in project governance and decision-making.
+* Access to advanced project resources and tools.
+* Ensure the quality and integrity of the specification.
+* Mentor and support new contributors.
+* Facilitate project meetings and discussions.
+* Maintain documentation and project standards.
+* Actively engage with the community and promote collaboration.
+
+#### Special Role: Normative Editor
+
+Every specification project has some appointed editors who are responsible for the following:
+* Ensuring that the specification meets established standards and guidelines.
+* Reviewing and revising the content for clarity, precision, and consistency.
+* Managing the formal aspects of the specification, including structure and formatting.
+* Collaborating with authors and contributors to align the document with project goals.
+* Ensuring that the specification is technically accurate.
+
+_As of 17.10.2024, this role will be assumed by every active Committer._
+
+#### Becoming a Committer
+
+Committers are appointed at the time of project creation or elected by the existing project team. To become a Committer, you need to have a proven track record covering significant contributions like:
+
+* Demonstrated expertise in the project
+* History of quality contributions
+* Community involvement in the GitHub Issues or Discussions section
+
+The Committer election process will always be initiated by existing Committers. They will contact you and ask your willingness to fulfil the Committer's rights and obligations. The project lead then starts the official EF Committer election process, which follows a democratic voting process. A list of active Committers is available on the [project's page](https://projects.eclipse.org/projects/technology.dataspace-protocol-base/who).
+
+#### Retirement of Committers
+
+Committers can retire themselves from a project at any point in time. In case of inactivity of a Committer for six months, the project lead is asked to put the retirement up for discussion. Before retiring a Committer, the project's community should be informed of the change, and the Committer must be given a chance to defend retaining their status.
+
+Retired Committers cannot appoint a person (e.g., from the same organisation) as a stand-in. New Committers **must** pass the official process of [becoming a Committer](#becoming-a-committer). Retired Committers are listed as "Historic Committers" on a [project's page](https://projects.eclipse.org/projects/technology.dataspace-protocol-base/who). To restore a Historic Committer to Committer status, they must be re-elected.
+
+
+## Contact Us
+
+If you have questions or suggestions, do not hesitate to contact the project developers via the [project's "dev" list](https://accounts.eclipse.org/mailing-list/dataspace-protocol-base-dev).
+
+We have bi-weekly Committer, and community calls on Thursdays. Please find the meeting information [in our discussion section](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/discussions/11).
+
+_If you have a "Committer" status, you will be automatically included in the meeting invite for the Committers meeting._

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/PR_ETIQUETTE.md
+++ b/PR_ETIQUETTE.md
@@ -1,0 +1,32 @@
+# Etiquette for Pull Requests
+
+## As a contributor
+
+Submitting pull requests should be done while adhering to a couple of simple rules.
+
+- Familiarize yourself with our [contribution guidelines](CONTRIBUTING.md).
+- Before you submit a PR, open a [discussion](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/discussions/new) or an [issue](https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/issues/new) outlining your planned work and give people time to comment. It may even be advisable to contact committers using the `@mention` feature. Unsolicited PRs may get ignored or rejected.
+- Create focused PRs: Your work should focus on one feature or bugfix. Do not create broad-scoped PRs that solve multiple issues, as reviewers may reject those PR bombs outright.
+- Provide a clear description and motivation in the PR description in GitHub. This makes the reviewer's life much easier. It is also helpful to outline the broad changes that were made.
+- All tests should be green, especially when your PR is in `"Ready for review"`
+- Mark PRs as `"Ready for review"` only when you're prepared to defend your work. By then, you have completed your work and shouldn't need to push any more commits other than to incorporate review comments.
+- Merge conflicts should be resolved by rebasing onto `main` and force-pushing. Do this when your PR is ready to review.
+- If you require a reviewer's input while it's still in draft, please get in touch with the designated reviewer using the `@mention` feature and let them know what you'd like them to look at.
+- Request a review from one of the [project's committers](https://projects.eclipse.org/projects/technology.dataspace-protocol-base/who). Requesting a review from anyone else is still possible and sometimes may be advisable. Still, only committers can merge PRs, so include them early on.
+- Re-request reviews after all remarks have been adopted. This helps reviewers track their work in GitHub.
+- If you disagree with a committer's remarks, feel free to object and argue. Still, if no agreement is reached, you must either accept the decision or withdraw your PR.
+- Be civil and objective. No foul language, insulting, or otherwise abusive language will be tolerated.
+- The PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+    - The title must follow the format as `<type>(<optional scope>): <description>`.
+      `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, and `test` are allowed for the `<type>`.
+    - The length must be kept under 80 characters.
+
+## As a reviewer
+
+- Please complete reviews within five business days or delegate to another committer, removing yourself as a reviewer.
+  If you have been requested as a reviewer but cannot do the review for any reason (time, lack of knowledge in a particular area, etc.), please comment on that in the PR and remove yourself as a reviewer, suggesting a stand-in.
+- Don't be overly pedantic.
+- Don't argue basic principles (e.g., protocol architecture).
+- Don't just wave through any PR. Please take the time to look at them carefully.
+- Be civil and objective. No foul language, insulting, or otherwise abusive language will be tolerated. The goal is to _encourage_ contributions.
+- Committers can merge PRs with the approval of one other committer, provided there are no objections.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# best-practices
-This repository contains non-normative companion documents for adopters of the Eclipse Decentralized Claims Protocol (DCP)
+# Best Practices involving the Decentralized Claims Protocol
+This repository collects various material that involve extending, implementing and working with the Decentralized Claims Protocol.


### PR DESCRIPTION
WHAT
- adds the initial documents for the best practices repository, similar to the DSP Best Practices
- update README text to make it more clear

How was the issue fixed?
The documents have been added