### PR TITLE
feat: add further elaboration on discussion on consent

### DIFF
--- a/consent/README.md
+++ b/consent/README.md
@@ -1,9 +1,9 @@
 # Discussion on Consent
 
-The specification already mentions parts on consent
+The DCP specification already mentions parts on consent
 in [§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent).
 
-The DCP considers two types of consent
+The dataspace protocol stack considers two types of consent:
 
 ## 1) Consent to Release Claims via Presentation of VCs
 
@@ -11,14 +11,19 @@ When a holder requests a dataset, at first the verifier must specify the require
 resource. After this, the consumer must agree to the release of the requested claims. Within the dataspace protocol
 stack, this happens in a machine-based fashion through an internal mapping from the policy constraints inside the [DSP
 Offer](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1/#dfn-offer) to the
-corresponding VCs to be released via DCP as described in 
+corresponding VCs to be released via DCP as described in
 [§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent). Thus, the
-claims to be presented may vary by offer. These mappings are dataspace-specific and are outside the scope of the DSP 
+claims to be presented may vary by offer. These mappings are dataspace-specific and are outside the scope of the DSP
 or DCP protocol specifications.
 
-## 2) Consent to an Agreement inside DSP
+## 2) Consent to an DSP Contract Negotiation Agreement
 
-In contrast to the first case, consent to an agreement can either happen in a machine-based fashion or through
-manual human approval. In the machine-based case, consent to an agreement is evaluated through an automated policy
-evaluation of the DSP request. Alternatively, within the DSP/DCP protocol stack also supports asynchronous
-protocol flows to support manual approval through end-user consent.
+In contrast to the first case, consent to a contract negotiation agreement can either take place in a machine-based
+fashion or through
+manual human approval. To this end, all steps defined in the Contract Negotiation state machine of the DSP
+protocol specification (see [DCP Contract Negotiation State Machine](https://eclipse-dataspace-protocol-base.github.
+io/DataspaceProtocol/2025-1-RC1/#state-machine)) can be evaluated in a machine-based way by an automated policy
+evaluation of the DSP request. However, any of these
+steps also support manual approvals instead,
+whereby the end-users of the respective organization can approve the agreement instead.
+

--- a/consent/README.md
+++ b/consent/README.md
@@ -1,10 +1,24 @@
 # Discussion on Consent
 
-The specification already mentions parts on consent in [§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent). 
+The specification already mentions parts on consent
+in [§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent).
 
 The DCP considers two types of consent
-## 1) Consent to Release Claims (via Presentation of VCs)
-When a consumer requests a dataset, at first the provider must specify the required claims to grant access to the data resource. After this, the consumer must agree to the release of the requested claims. Within the dataspace protocol stack, this happens in a machine-based fashion through an internal mapping between the DCP policy constraints and the corresponding Verifiable Credentials to be released via DCP. These mappings are always dataspace-specific and outside the scope of the protocol specifications.
 
-## 2) Consent to an Agreement
-In contrast to the first case, consent to an agreement can either also happen in a machine-based fashion or through manual human approval. In the machine-based case, consent to an agreement is evaluated through an automated policy evaluation of the DSP request. Alternatively, the DCP also supports asynchronous protocol flows to support manual approval through end-user consent.
+## 1) Consent to Release Claims via Presentation of VCs
+
+When a holder requests a dataset, at first the verifier must specify the required claims to grant access to the data
+resource. After this, the consumer must agree to the release of the requested claims. Within the dataspace protocol
+stack, this happens in a machine-based fashion through an internal mapping from the policy constraints inside the [DSP
+Offer](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1/#dfn-offer) to the
+corresponding VCs to be released via DCP as described in 
+[§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent). Thus, the
+claims to be presented may vary by offer. These mappings are dataspace-specific and are outside the scope of the DSP 
+or DCP protocol specifications.
+
+## 2) Consent to an Agreement inside DSP
+
+In contrast to the first case, consent to an agreement can either happen in a machine-based fashion or through
+manual human approval. In the machine-based case, consent to an agreement is evaluated through an automated policy
+evaluation of the DSP request. Alternatively, within the DSP/DCP protocol stack also supports asynchronous
+protocol flows to support manual approval through end-user consent.

--- a/consent/README.md
+++ b/consent/README.md
@@ -1,0 +1,10 @@
+# Discussion on Consent
+
+The specification already mentions parts on consent in [§ 3.1 Consent](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0-RC2/#consent). 
+
+The DCP considers two types of consent
+## 1) Consent to Release Claims (via Presentation of VCs)
+When a consumer requests a dataset, at first the provider must specify the required claims to grant access to the data resource. After this, the consumer must agree to the release of the requested claims. Within the dataspace protocol stack, this happens in a machine-based fashion through an internal mapping between the DCP policy constraints and the corresponding Verifiable Credentials to be released via DCP. These mappings are always dataspace-specific and outside the scope of the protocol specifications.
+
+## 2) Consent to an Agreement
+In contrast to the first case, consent to an agreement can either also happen in a machine-based fashion or through manual human approval. In the machine-based case, consent to an agreement is evaluated through an automated policy evaluation of the DSP request. Alternatively, the DCP also supports asynchronous protocol flows to support manual approval through end-user consent.


### PR DESCRIPTION
## What this PR changes/adds

- adds document on discussion of consent

Related to Discussion #200 in the DCP specification repository

## Why it does that
- the discussion on consent in the specification should be extended in the best practices